### PR TITLE
feat: add tray icon theme setting

### DIFF
--- a/manage_window.cpp
+++ b/manage_window.cpp
@@ -17,6 +17,8 @@
 #include <QDateTime>
 #include <QSettings>
 #include <QCheckBox>
+#include <QComboBox>
+#include <QLabel>
 
 #include <cctype>
 #include <sdbus-c++/Types.h>
@@ -51,6 +53,25 @@ ManageWindow::ManageWindow(iwd &manager, QWidget *parent): QDialog(parent), mana
 
     connect(showNotificationsCheckbox, &QCheckBox::checkStateChanged, this, [=, this]{
         settings.setValue(SHOW_NOTIFICATIONS_SETTING, showNotificationsCheckbox->isChecked());
+    });
+
+    auto currentIconTheme = settings.value(ICON_THEME_SETTING, ICON_THEME_AUTO).toString();
+    if(currentIconTheme != ICON_THEME_DARK && currentIconTheme != ICON_THEME_LIGHT) {
+        currentIconTheme = ICON_THEME_AUTO;
+    }
+
+    auto iconThemeIndex = iconThemeComboBox->findData(currentIconTheme);
+    if(iconThemeIndex >= 0) {
+        iconThemeComboBox->setCurrentIndex(iconThemeIndex);
+    }
+
+    connect(iconThemeComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, [this](int index) {
+        if(index < 0) {
+            return;
+        }
+
+        settings.setValue(ICON_THEME_SETTING, iconThemeComboBox->itemData(index).toString());
+        emit iconThemeChanged();
     });
 
     connect(refreshButton, &QPushButton::clicked, this, [=, this]{
@@ -250,6 +271,12 @@ void ManageWindow::createItems(){
     avoidScansCheckbox = new QCheckBox("Avoid scans", this);
     showNotificationsCheckbox = new QCheckBox("Show notifications", this);
 
+    iconThemeLabel = new QLabel(tr("Icon theme"), this);
+    iconThemeComboBox = new QComboBox(this);
+    iconThemeComboBox->addItem(tr("Auto"), QString(ICON_THEME_AUTO));
+    iconThemeComboBox->addItem(tr("Dark Panel"), QString(ICON_THEME_DARK));
+    iconThemeComboBox->addItem(tr("Light Panel"), QString(ICON_THEME_LIGHT));
+
     refreshButton = new QPushButton("Refresh", this);
     refreshButton->setFixedSize(95, 25);
 
@@ -262,6 +289,12 @@ void ManageWindow::createItems(){
 
     layout->addWidget(listWidget);
 
+    QHBoxLayout *iconThemeLayout = new QHBoxLayout();
+
+    iconThemeLayout->addStretch();
+    iconThemeLayout->addWidget(iconThemeLabel);
+    iconThemeLayout->addWidget(iconThemeComboBox);
+
     QHBoxLayout *layout2 = new QHBoxLayout();
     
     layout2->addStretch();
@@ -271,7 +304,7 @@ void ManageWindow::createItems(){
     layout2->addWidget(refreshButton);
     layout2->addWidget(addButton);
 
-
+    layout->addLayout(iconThemeLayout);
     layout->addLayout(layout2);
 }
 

--- a/manage_window.hpp
+++ b/manage_window.hpp
@@ -16,7 +16,9 @@ class QHBoxLayout;
 class QPushButton;
 class QCloseEvent;
 class QToolButton;
-class QCheckbox;
+class QCheckBox;
+class QComboBox;
+class QLabel;
 QT_END_NAMESPACE
 
 Q_DECLARE_METATYPE(known_network);
@@ -32,6 +34,9 @@ class ManageWindow: public QDialog{
 
     public:
         ManageWindow(iwd &manager, QWidget *parent = nullptr);
+
+    signals:
+        void iconThemeChanged();
         
     protected:
         void keyPressEvent(QKeyEvent *event) override;
@@ -49,6 +54,8 @@ class ManageWindow: public QDialog{
         QPushButton *addButton;
         QCheckBox *avoidScansCheckbox;
         QCheckBox *showNotificationsCheckbox;
+        QLabel *iconThemeLabel;
+        QComboBox *iconThemeComboBox;
 
         ManageWindow *mwindow;
 

--- a/tray.cpp
+++ b/tray.cpp
@@ -32,8 +32,7 @@
 #include <unistd.h>
 
 Tray::Tray(iwd &in): manager(in) {
-    isDarkMode = 
-        this->palette().window().color().value() < this->palette().windowText().color().value();
+    updateIconTheme();
 
     createTray();
 
@@ -196,6 +195,23 @@ void Tray::makeAgent() {
     };
 
     this->manager.register_agent(std::move(ui));
+}
+
+void Tray::updateIconTheme() {
+    auto iconTheme = settings.value(ICON_THEME_SETTING, ICON_THEME_AUTO).toString();
+
+    if(iconTheme == ICON_THEME_DARK) {
+        isDarkMode = true;
+        return;
+    }
+
+    if(iconTheme == ICON_THEME_LIGHT) {
+        isDarkMode = false;
+        return;
+    }
+
+    isDarkMode =
+        this->palette().window().color().value() < this->palette().windowText().color().value();
 }
 
 void Tray::connectedHandler(network n, QPixmap icon){
@@ -417,4 +433,13 @@ void Tray::fillMenu() {
 
 void Tray::createManageWindow(){
     mwindow = new ManageWindow(manager, this);
+    connect(mwindow, &ManageWindow::iconThemeChanged, this, [this] {
+        updateIconTheme();
+
+        try {
+            refreshTray(false);
+        } catch(...) {
+            instantiateDevice();
+        }
+    });
 }

--- a/tray.cpp
+++ b/tray.cpp
@@ -9,6 +9,7 @@
 
 #include <QWidgetAction>
 #include <QAction>
+#include <QActionGroup>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QCoreApplication>
@@ -31,9 +32,12 @@
 #include <cstdio>
 #include <unistd.h>
 
+constexpr auto ICON_THEME_AUTO = "auto";
+constexpr auto ICON_THEME_DARK = "dark";
+constexpr auto ICON_THEME_LIGHT = "light";
+
 Tray::Tray(iwd &in): manager(in) {
-    isDarkMode = 
-        this->palette().window().color().value() < this->palette().windowText().color().value();
+    updateIconTheme();
 
     createTray();
 
@@ -196,6 +200,23 @@ void Tray::makeAgent() {
     };
 
     this->manager.register_agent(std::move(ui));
+}
+
+void Tray::updateIconTheme() {
+    auto iconTheme = settings.value(ICON_THEME_SETTING, ICON_THEME_AUTO).toString();
+
+    if(iconTheme == ICON_THEME_DARK) {
+        isDarkMode = true;
+        return;
+    }
+
+    if(iconTheme == ICON_THEME_LIGHT) {
+        isDarkMode = false;
+        return;
+    }
+
+    isDarkMode =
+        this->palette().window().color().value() < this->palette().windowText().color().value();
 }
 
 void Tray::connectedHandler(network n, QPixmap icon){
@@ -406,6 +427,7 @@ void Tray::fillMenu() {
 
     trayIconMenu->addMenu(networksMenu);
     trayIconMenu->addAction(scanAction);
+    trayIconMenu->addMenu(createIconThemeMenu());
 
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(manageAction);
@@ -413,6 +435,41 @@ void Tray::fillMenu() {
 
     trayIcon->setContextMenu(trayIconMenu);
     trayIcon->show();
+}
+
+QMenu *Tray::createIconThemeMenu() {
+    auto menu = new QMenu(tr("&Icon Theme"), this);
+    auto group = new QActionGroup(menu);
+    group->setExclusive(true);
+
+    auto currentTheme = settings.value(ICON_THEME_SETTING, ICON_THEME_AUTO).toString();
+    if(currentTheme != ICON_THEME_DARK && currentTheme != ICON_THEME_LIGHT) {
+        currentTheme = ICON_THEME_AUTO;
+    }
+
+    auto addThemeAction = [this, menu, group, currentTheme](const QString &label, const char *value) {
+        auto action = menu->addAction(label);
+        action->setCheckable(true);
+        action->setChecked(currentTheme == value);
+        group->addAction(action);
+
+        connect(action, &QAction::triggered, this, [this, value] {
+            settings.setValue(ICON_THEME_SETTING, value);
+            updateIconTheme();
+
+            try {
+                refreshTray(false);
+            } catch(...) {
+                instantiateDevice();
+            }
+        });
+    };
+
+    addThemeAction(tr("&Auto"), ICON_THEME_AUTO);
+    addThemeAction(tr("&Dark Panel"), ICON_THEME_DARK);
+    addThemeAction(tr("&Light Panel"), ICON_THEME_LIGHT);
+
+    return menu;
 }
 
 void Tray::createManageWindow(){

--- a/tray.hpp
+++ b/tray.hpp
@@ -54,6 +54,7 @@ class Tray : public QDialog {
     void updateEnabledTray(bool);
     void refreshTray(bool);
     void makeAgent();
+    void updateIconTheme();
 
     std::string requestPassphrase(const std::string& path);
     std::tuple<std::string,std::string> requestUserAndPassphrase(const std::string& path);

--- a/tray.hpp
+++ b/tray.hpp
@@ -54,12 +54,14 @@ class Tray : public QDialog {
     void updateEnabledTray(bool);
     void refreshTray(bool);
     void makeAgent();
+    void updateIconTheme();
 
     std::string requestPassphrase(const std::string& path);
     std::tuple<std::string,std::string> requestUserAndPassphrase(const std::string& path);
 
     void createItems();
     void fillMenu();
+    QMenu *createIconThemeMenu();
     void createManageWindow();
 
     void connectedHandler(network n, QPixmap icon);

--- a/utils.hpp
+++ b/utils.hpp
@@ -14,6 +14,10 @@ namespace Utils{
 constexpr auto SORT_SETTING = "sort_type";
 constexpr auto AVOID_SCANS_SETTING = "avoid_scans";
 constexpr auto SHOW_NOTIFICATIONS_SETTING = "show_notifications";
+constexpr auto ICON_THEME_SETTING = "icon_theme";
+constexpr auto ICON_THEME_AUTO = "auto";
+constexpr auto ICON_THEME_DARK = "dark";
+constexpr auto ICON_THEME_LIGHT = "light";
 
 constexpr auto EXCELLENT_ICON_PATH = ":/images/wireless-4.svg";
 constexpr auto GOOD_ICON_PATH = ":/images/wireless-3.svg";

--- a/utils.hpp
+++ b/utils.hpp
@@ -14,6 +14,7 @@ namespace Utils{
 constexpr auto SORT_SETTING = "sort_type";
 constexpr auto AVOID_SCANS_SETTING = "avoid_scans";
 constexpr auto SHOW_NOTIFICATIONS_SETTING = "show_notifications";
+constexpr auto ICON_THEME_SETTING = "icon_theme";
 
 constexpr auto EXCELLENT_ICON_PATH = ":/images/wireless-4.svg";
 constexpr auto GOOD_ICON_PATH = ":/images/wireless-3.svg";


### PR DESCRIPTION
On my Hyprland setup, the tray icon was showing up as a dark icon on a dark panel, so it was basically hard to see.

I added an `Icon Theme` option to the manage menu so this can be set manually when the automatic Qt palette detection gets it wrong.

The menu has three options:

- `Auto` keeps the current behavior
- `Dark Panel` uses the light icons
- `Light Panel` uses the dark icons

The selected option is saved with the existing app settings, and the tray icon refreshes right after changing it.
